### PR TITLE
Fix: Incorrect number formatting

### DIFF
--- a/src/Pages/Records.tsx
+++ b/src/Pages/Records.tsx
@@ -6,11 +6,10 @@ import Record from '../Models/Record';
 
 // https://stackoverflow.com/a/52560608
 const format = (val: number) => `0${Math.floor(val)}`.slice(-2);
-function formatTime(timeS: number) {
-    const hours = timeS / 3600;
-    const minutes = (timeS % 3600) / 60;
-    const seconds = timeS % 60;
-
+function formatTime(timeInMs: number) {
+    const hours = timeInMs / 3.6e+6;
+    const minutes = timeInMs / 60000;
+    const seconds = (timeInMs / 1000) % 60;
     return [hours, minutes, seconds].map(format).join(':');
 }
 


### PR DESCRIPTION
The `formatTime` helper function expects time in seconds, but receives it in miliseconds - resulting in numbers being formatted incorrectly.